### PR TITLE
Adding support for Terraform and Groovy Jinja templating. (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Change Log
+## [0.10.1] - 2019-11-06
+* add python support by @chrisweissnike
 
 ## [0.10.0] - 2019-04-06
 * add python support by @lukesneeringer #21

--- a/README.md
+++ b/README.md
@@ -70,11 +70,23 @@ Jinja SQL templates: system name `jinja-sql`.
 
 Default file assocations: `.sql.j2`, `.sql.jinja` and `.sql.jinja2`.
 
-### Jinja Pyhton
+### Jinja Python
 
 Jinja python templates: system name `jinja-py`.
 
 Default file assocations: `.py.j2`, `.py.jinja` and `.py.jinja2`.
+
+### Jinja Terraform
+
+Jinja Terraform templates: system name `jinja-terraform`.
+
+Default file assocations: `.tf.j2`, `.tf.jinja`, `.tf.jinja2`, `.tfvars.j2`, `.tfvars.jinja`, and `.tfvars.jinja2`.
+
+### Jinja Groovy
+
+Jinja Groovy templates: system name `jinja-groovy`.
+
+Default file assocations: `.groovy.j2`, `.groovy.jinja` and `.groovy.jinja2`.
 
 ## Extra File Associations
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jinjahtml",
   "displayName": "Better Jinja",
   "description": "Syntax highlighting for jinja(2) including HTML, Markdown, YAML, Ruby and LaTeX templates",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "publisher": "samuelcolvin",
   "author": "Samuel Colvin",
   "engines": {
@@ -100,6 +100,18 @@
         "aliases": ["Jinja Raw", "jinja-raw"],
         "extensions": [],
         "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "jinja-terraform",
+        "aliases": ["Jinja Terraform", "jinja-terraform"],
+        "extensions": [".tf.j2", ".tf.jinja", ".tf.jinja2", ".tfvars.j2", ".tfvars.jinja", ".tfvars.jinja2"],
+        "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "jinja-groovy",
+        "aliases": ["Jinja Groovy", "jinja-groovy"],
+        "extensions": [".groovy.j2", ".groovy.jinja", ".groovy.jinja2"],
+        "configuration": "./language-configuration.json"
       }
     ],
     "grammars": [
@@ -162,6 +174,16 @@
         "language": "jinja",
         "scopeName": "source.jinja",
         "path": "./syntaxes/jinja.tmLanguage.json"
+      },
+      {
+        "language": "jinja-groovy",
+        "scopeName": "source.groovy.jinja",
+        "path": "./syntaxes/jinja-groovy.tmLanguage.json"
+      },
+      {
+        "language": "jinja-terraform",
+        "scopeName": "source.terraform.jinja",
+        "path": "./syntaxes/jinja-terraform.tmLanguage.json"
       }
     ],
     "snippets": [

--- a/syntaxes/jinja-groovy.tmLanguage.json
+++ b/syntaxes/jinja-groovy.tmLanguage.json
@@ -1,0 +1,13 @@
+{
+  "name": "jinja-groovy",
+  "scopeName": "source.groovy.jinja",
+  "comment": "Jinja Groovy Templates",
+  "patterns": [
+    {
+      "include": "source.jinja"
+    },
+    {
+      "include": "source.groovy"
+    }
+  ]
+}

--- a/syntaxes/jinja-terraform.tmLanguage.json
+++ b/syntaxes/jinja-terraform.tmLanguage.json
@@ -1,0 +1,13 @@
+{
+  "name": "jinja-terraform",
+  "scopeName": "source.terraform.jinja",
+  "comment": "Jinja terraform Templates",
+  "patterns": [
+    {
+      "include": "source.jinja"
+    },
+    {
+      "include": "source.terraform"
+    }
+  ]
+}


### PR DESCRIPTION
* Adding support for Terraform and Groovy Jinja templating.

* Updating Readme and changelog to indicate updated Groovy/Terraform support.
Bumped rev number in package.json
Added ".jinja" and ".jinja2" to Terraform and Groovy supported extensions.